### PR TITLE
feat: create header component

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,11 @@
+import Logo from "./Logo";
+
+const Header = () => {
+  return (
+    <header className="fixed top-0 flex items-center justify-center w-full py-2 backdrop-blur-md bg-neutral-50/1">
+      <Logo />
+    </header>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
Created a header component that will be used in the mobile version of the website. It's fixed and has a blurred background.

Image of the header:
<img width="405" height="317" alt="image" src="https://github.com/user-attachments/assets/8112d146-f51e-476d-a5ed-d999c105f886" />
