### PR TITLE
feat: create edit button component

### DIFF
--- a/frontend/src/components/EditButton.tsx
+++ b/frontend/src/components/EditButton.tsx
@@ -1,0 +1,18 @@
+import { Icon } from "@iconify/react";
+
+interface EditButtonProps {
+  onClick?: () => void;
+}
+
+const EditButton: React.FC<EditButtonProps> = ({ onClick }) => {
+  return (
+    <button title="Edit" onClick={onClick}>
+      <Icon
+        icon="ant-design:edit-filled"
+        className="size-5 text-neutral-925 hover:text-accent active:text-accent cursor-pointer transition-colors duration-200"
+      ></Icon>
+    </button>
+  );
+};
+
+export default EditButton;


### PR DESCRIPTION
Created a simple reusable editbutton that will be connected to the backend logic when created.

Edit button:
<img width="26" height="26" alt="image" src="https://github.com/user-attachments/assets/65aef2b2-d397-4e01-891c-30f94fafd97f" />


Edit button when hovering:
<img width="76" height="65" alt="image" src="https://github.com/user-attachments/assets/81c8f2cb-7fcd-4132-b802-de4e12494bf9" />
