### PR TITLE
Create button

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -10,7 +10,7 @@ const Button: React.FC<ButtonProps> = ({
   onClick,
   variant = "default",
   type = "button",
-  className = "rounded-",
+  className = "",
 }) => {
   const styles = {
     default: " bg-primary hover:bg-accent active:bg-accent",


### PR DESCRIPTION
Created a reusable button component with support for two variants and styling.

Key details:
- Has a default and dark variant
- Accepts children for content e.g text
- Has optional onClick, type, and className props

Default:
<img width="214" height="130" alt="image" src="https://github.com/user-attachments/assets/d8487586-403b-4514-88f6-468443a4bec4" />

Dark variant:
<img width="214" height="129" alt="image" src="https://github.com/user-attachments/assets/0967ad87-19ce-44ec-8d3c-d50e0ad4a00b" />
