### PR TITLE
feat: create total sum component

### DIFF
--- a/frontend/src/components/TotalSum.tsx
+++ b/frontend/src/components/TotalSum.tsx
@@ -1,0 +1,14 @@
+interface TotalSumProps {
+  total?: number;
+}
+
+const TotalSum: React.FC<TotalSumProps> = ({ total = 0 }) => {
+  return (
+    <div className="flex flex-col p-6 bg-primary text-neutral-50 gap-2 rounded-xl max-w-md">
+      <p className="text-xl font-medium">Total cost this month</p>
+      <p className="text-5xl font-semibold">{total} kr</p>
+    </div>
+  );
+};
+
+export default TotalSum;


### PR DESCRIPTION
Created a reusable total sum component for showing the total monthly subscription cost on the home page. Currently uses static data and will later be connected to backend data.

The component in question:
<img width="456" height="147" alt="image" src="https://github.com/user-attachments/assets/5393ca37-51e3-4951-b2f7-64af335818d0" />
