### PR TITLE
Create card

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -54,6 +54,21 @@ const Card: React.FC<CardProps> = ({
           </div>
         </div>
       )}
+      {variant === "Company" && (
+        <div className="flex items-center w-full justify-between">
+          <div className="flex gap-4 items-center">
+            {image && (
+              <img src={image} alt={company} className="size-12 flex" />
+            )}
+            <div className="flex flex-col">
+              {company && <p className="text-lg font-medium">{company}</p>}
+            </div>
+          </div>
+          <button title="Add subscription" onClick={onAdd}>
+          <Icon icon="icon-park-solid:add" className="size-9 text-primary hover:text-accent active:text-accent cursor-pointer" />
+        </button>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Created a reusable card component.

Key details:
- Includes three variants: Sub, MySub, and Company
- Supports optional company, description, price, image, and onAdd props

Will be connected to backend later in the project. 

An example of the three variants (Sub, MySub, Company:
<img width="362" height="353" alt="image" src="https://github.com/user-attachments/assets/1c66f673-1809-45fa-8f33-113bf0339591" />
