### PR TITLE
Create modal

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -15,6 +15,8 @@ interface ModalProps {
     description?: string;
     price?: string;
   };
+
+  confirmMessage?: string;
 }
 
 const Modal: React.FC<ModalProps> = ({
@@ -25,6 +27,7 @@ const Modal: React.FC<ModalProps> = ({
   company,
   image,
   defaultValue,
+  confirmMessage,
 }) => {
   const [description, setDescription] = useState("");
   const [price, setPrice] = useState("");
@@ -129,6 +132,28 @@ const Modal: React.FC<ModalProps> = ({
                 </Button>
               </div>
             </form>
+          </>
+        )}
+
+        {variant === "Confirm" && (
+          <>
+            <h2 className="text-2xl font-semibold">Wait!</h2>
+            <p className="font-medium">{confirmMessage}</p>
+
+            <div className="flex items-start gap-4">
+              <Button
+                type="button"
+                onClick={() => {
+                  onSubmit({ description: "", price: "" });
+                  onClose();
+                }}
+              >
+                Confirm
+              </Button>
+              <Button type="button" variant="dark" onClick={onClose}>
+                Cancel
+              </Button>
+            </div>
           </>
         )}
       </div>


### PR DESCRIPTION
Created a reusable modal component supporting three variants:
1. **AddSub:** add a new subscription with description and price field
2. **EditSub:** edit an existing subscription, inputs are pre filled with the default values
3. **Confirm:** display confirmation messages for actions like delete or overwriting

Key details:
- defaultValue prop allows pre filling EditSub form
- confirmMessage prop allows customizable text for Confirm variant 
- Resets form fields on modal close

Once backend is connected the modals will display the correct company, image, and subscription data dynamically and the Confirm variant won't send empty description and price strings

Modal component:

https://github.com/user-attachments/assets/d4badacf-f73a-45bd-be68-497979d91549

