### PR TITLE
feat: add auth middleware

### DIFF
--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -99,24 +99,27 @@ export const getProfile = async (
   }
 };
 
-export const subscribeEmail = async (
+export const toggleSubscription = async (
   request: FastifyRequest,
   reply: FastifyReply
 ) => {
   try {
     const userId = (request as any).userId;
 
-    const user = await User.findByIdAndUpdate(
-      userId,
-      { role: "subscriber" },
-      { new: true }
-    );
+    const user = await User.findById(userId);
     if (!user) return reply.status(404).send({ error: "User not found" });
 
-    reply.send({ message: "Subscribed to emails", user });
+    const willSubscribe = user.role !== "subscriber";
+    user.role = willSubscribe ? "subscriber" : "default";
+    await user.save();
+
+    reply.send({
+      message: `Subscription ${willSubscribe ? "enabled" : "disabled"}`,
+      user,
+    });
   } catch (error) {
     reply
       .status(500)
-      .send({ error: "Failed to subscribe to emails", details: error });
+      .send({ error: "Failed to update subscription status", details: error });
   }
 };

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,29 @@
+import { FastifyRequest, FastifyReply } from "fastify";
+import jwt from "jsonwebtoken";
+
+export const auth = async (request: FastifyRequest, reply: FastifyReply) => {
+  try {
+    const authHeader = request.headers["authorization"];
+    if (!authHeader) {
+      return reply.status(401).send({ error: "Authorization header missing " });
+    }
+
+    const token = authHeader.split(" ")[1];
+    if (!token) {
+      return reply.status(401).send({ error: "Token missing" });
+    }
+
+    const decoded = jwt.verify(
+      token,
+      process.env.JWT_SECRET || "secretkey"
+    ) as {
+      userId: string;
+      role: string;
+    };
+
+    (request as any).userId = decoded.userId;
+    (request as any).role = decoded.role;
+  } catch (error) {
+    return reply.status(401).send({ error: "Invalid or expired token" });
+  }
+};

--- a/backend/src/routes/subscriptionRoutes.ts
+++ b/backend/src/routes/subscriptionRoutes.ts
@@ -6,20 +6,38 @@ import {
   listAllSubscriptions,
   listUserSubscriptions,
 } from "../controllers/subscriptionController";
+import { auth } from "../middleware/auth";
 
 export default async function subscriptionRoutes(fastify: FastifyInstance) {
   fastify.get("/subscriptions", listAllSubscriptions);
 
-  fastify.get("/users/:userId/subscriptions", listUserSubscriptions);
+  fastify.get(
+    "/users/:userId/subscriptions",
+    { preHandler: auth },
+    listUserSubscriptions
+  );
 
-  fastify.post("/users/:userId/subscriptions", addSubscription);
+  fastify.post(
+    "/users/:userId/subscriptions",
+    { preHandler: auth },
+    addSubscription
+  );
 
-  fastify.patch("/users/:userId/subscriptions/:id", editSubscription);
+  fastify.patch(
+    "/users/:userId/subscriptions/:id",
+    { preHandler: auth },
+    editSubscription
+  );
 
-  fastify.delete("/users/:userId/subscriptions/:id", deleteSubscription);
+  fastify.delete(
+    "/users/:userId/subscriptions/:id",
+    { preHandler: auth },
+    deleteSubscription
+  );
 
   fastify.get(
     "/users/:userId/subscriptions/statistics",
+    { preHandler: auth },
     async (request, reply) => {}
   );
 }

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -6,15 +6,16 @@ import {
   registerUser,
   subscribeEmail,
 } from "../controllers/userController";
+import { auth } from "../middleware/auth";
 
 export default async function userRoutes(fastify: FastifyInstance) {
   fastify.post("/users/register", registerUser);
 
   fastify.post("/users/login", loginUser);
 
-  fastify.post("/users/logout", logoutUser);
+  fastify.post("/users/logout", { preHandler: auth }, logoutUser);
 
-  fastify.get("/users/profile", getProfile);
+  fastify.get("/users/profile", { preHandler: auth }, getProfile);
 
-  fastify.patch("/users/subscribe", subscribeEmail);
+  fastify.patch("/users/subscribe", { preHandler: auth }, subscribeEmail);
 }

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -4,7 +4,7 @@ import {
   loginUser,
   logoutUser,
   registerUser,
-  subscribeEmail,
+  toggleSubscription,
 } from "../controllers/userController";
 import { auth } from "../middleware/auth";
 
@@ -17,5 +17,5 @@ export default async function userRoutes(fastify: FastifyInstance) {
 
   fastify.get("/users/profile", { preHandler: auth }, getProfile);
 
-  fastify.patch("/users/subscribe", { preHandler: auth }, subscribeEmail);
+  fastify.patch("/users/subscribe", { preHandler: auth }, toggleSubscription);
 }


### PR DESCRIPTION
In this pull request i:
- Added authentication middleware to protect routes requiring login
- Updated subscription routes to require authentication
- Refactored email subscription endpoint to toggle subscription instead of just being able to subscribe (users can now subscribe and unsubscribe to emails)

Everything was tested in Insomnia and is functional